### PR TITLE
docs(getting-started): fix clone URL -> github.com/tri-onyx/tri-onyx

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,8 +21,8 @@ This guide walks you through setting up a working TriOnyx instance from a fresh 
 ## 1. Clone and bootstrap
 
 ```bash
-git clone https://github.com/anthropics/TriOnyx.git
-cd TriOnyx
+git clone https://github.com/tri-onyx/tri-onyx.git
+cd tri-onyx
 ```
 
 ### Install git hooks


### PR DESCRIPTION
## Summary

\`docs/getting-started.md\` told users to clone \`https://github.com/anthropics/TriOnyx.git\`, but the project's public repo is \`https://github.com/tri-onyx/tri-onyx\`. Updated the \`git clone\` line and the follow-up \`cd\` to match, so the Getting Started walkthrough actually works copy-pasted.

Closes #32

## Testing

Docs-only change. Verified:
- README already links to \`github.com/tri-onyx/tri-onyx\` as the project repo;
- old URL \`github.com/anthropics/TriOnyx\` is not published.